### PR TITLE
feat: Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: "[BUG]"
+labels: ''
+assignees: ''
+
+---
+
+Please provide as many details as possible; this will help us deliver a fix as soon as possible.
+Thank you!
+
+### Description of the Bug
+
+A short, concise description of the bug and why you consider it a bug. Any details like exceptions and logs can be helpful as well.
+
+### Expected Behavior
+
+A description of what you would expect to happen. (Sometimes it is clear what the expected outcome is if something does not work; other times, it is not super clear.)
+
+### Minimal Reproducible Example
+
+We would appreciate the minimum code with which we can reproduce the issue.
+
+### Versions
+
+- Vaadin Flow/Hilla Framework Version: e.g., 24.3.2
+- Copilot Version: Mention the version number of Copilot.
+- Browser Information: e.g., Chrome 96.0.4664.110
+- Additional Information: (Is there anything else you can add about the proposal?)

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,7 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-title: ''
+title: "[FEATURE]"
 labels: ''
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,14 +7,16 @@ assignees: ''
 
 ---
 
-**Is your feature request related to a problem? Please describe.**
+
+
+###  Is your feature request related to a problem? Please describe.
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
-**Describe the solution you'd like**
+### Describe the solution you'd like
 A clear and concise description of what you want to happen.
 
-**Describe alternatives you've considered**
+### Describe alternatives you've considered
 A clear and concise description of any alternative solutions or features you've considered.
 
-**Additional context**
+### Additional context
 Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -9,14 +9,18 @@ assignees: ''
 
 
 
-###  Is your feature request related to a problem? Please describe.
+###  Is your feature request related to a problem?
+
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
 ### Describe the solution you'd like
+
 A clear and concise description of what you want to happen.
 
 ### Describe alternatives you've considered
+
 A clear and concise description of any alternative solutions or features you've considered.
 
 ### Additional context
-Add any other context or screenshots about the feature request here.
+
+Add any other context or screenshots, logs, videos about the feature request here.


### PR DESCRIPTION
Update the issue (separate feature and bug) templates based on GitHub's suggestions and what we use in other projects.

Let me know what you think:
- Is it sufficient?
- Are some changes needed?
- Does something else need to be added to these templates?